### PR TITLE
update: change Spotube version to 3.4.1 & change the app name to Spotube with capital S

### DIFF
--- a/Casks/spotube.rb
+++ b/Casks/spotube.rb
@@ -15,7 +15,7 @@ cask 'spotube' do
 
   depends_on macos: '>= :mojave'
 
-  app 'spotube.app'
+  app 'Spotube.app'
 
   caveats { unsigned_accessibility }
 end

--- a/Casks/spotube.rb
+++ b/Casks/spotube.rb
@@ -1,6 +1,6 @@
 cask 'spotube' do
-  version '3.4.0'
-  sha256 '7627f679cdfb40bf4554f1a0aaabed076cd15fa3f7342b61e45167a40491fc0b'
+  version '3.4.1'
+  sha256 '5686cb0b1b261399062250c36b7bf9c481e4c36c76615d787e01c77036fe6cba'
 
   url "https://github.com/KRTirtho/spotube/releases/download/v#{version}/Spotube-macos-universal.dmg",
       verified: 'github.com/KRTirtho/spotube/releases/download/'


### PR DESCRIPTION
New version 3.4.1 of Spotube is out

The change to Spotube.app with capital S better fits with naming conventions used for MacOS apps